### PR TITLE
Added looseMatching option

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -11,18 +11,16 @@ import {randomBytes, createCipheriv, createDecipheriv} from 'crypto'
 const forMatchingColumns = (entity: ObjectLiteral, cb: (propertyName: string, options: EncryptionOptions) => void) => {
   // Iterate through all columns in Typeorm
   getMetadataArgsStorage().columns.forEach((column) => {
-    // If this column is from the current entity
-    if(entity.constructor === column.target){
-      let {options, propertyName} = column
-      let columnOptions = options as EncryptedColumnOptions
-
-      if(
-        columnOptions.encrypt // Does this column have encryption options
-        &&
-        column.mode === 'regular' // Is it a regular column
-        &&
-        entity[propertyName] // Does the passed entity have the property
-      ){
+    const {options, propertyName, mode, target} = column
+    const columnOptions = options as EncryptedColumnOptions
+    if(
+      columnOptions.encrypt // Does this column have encryption options
+      &&
+      mode === 'regular' // Is it a regular column
+      &&
+      (columnOptions.encrypt.looseMatching || entity.constructor === target) // Is looseMatching enabled OR is this column from the current entity?
+    ){
+      if (entity[propertyName]) {  // Does the passed entity have the property?
         cb(propertyName, columnOptions.encrypt)
       }
     }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -13,6 +13,8 @@ export interface EncryptionOptions{
   algorithm: string
   /** IV Length to use in bytes. */
   ivLength: number
+  /** Loose matching skips the column/entity relationship check */
+  looseMatching?: boolean
 }
 
 export const EncryptedColumn = (options: EncryptedColumnOptions) => {


### PR DESCRIPTION
This PR adds a looseMatching option which, if enabled, skip the entity/column relationship check.