### PR TITLE
Fix dupplicate property process on inheritance

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -74,14 +74,15 @@ const encryptString = (string: string, options: EncryptionOptions) => {
  * Checks the supplied entity for columns that need decrypting and decrypts them.
  *
  * @param entity The typeorm entity to check
+ * @param includeProperties
  */
-export const decrypt = (entity: ObjectLiteral) => {
+export const decrypt = <T extends ObjectLiteral>(entity: T, includeProperties: string[] = []): T => {
     if (!entity) return entity
 
     forMatchingColumns(entity, (propertyName, options) => {
         // For any matching columns decrypt the property
         entity[propertyName] = decryptString(entity[propertyName], options)
-    })
+    }, includeProperties)
 
     return entity
 }

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,6 +1,6 @@
-import {getMetadataArgsStorage, ObjectLiteral} from 'typeorm';
-import {EncryptedColumnOptions, EncryptionOptions} from './interfaces';
-import {createCipheriv, createDecipheriv, randomBytes} from 'crypto';
+import {getMetadataArgsStorage, ObjectLiteral} from 'typeorm'
+import {EncryptedColumnOptions, EncryptionOptions} from './interfaces'
+import {createCipheriv, createDecipheriv, randomBytes} from 'crypto'
 
 /**
  * For all columns that have encryption options run the supplied function.
@@ -12,28 +12,28 @@ import {createCipheriv, createDecipheriv, randomBytes} from 'crypto';
 const forMatchingColumns = (entity: ObjectLiteral, cb: (propertyName: string, options: EncryptionOptions) => void, includeProperties: string[] = []) => {
     // Iterate through all columns in Typeorm
     let validColumns = getMetadataArgsStorage().columns
-        .filter(({options, mode, target, propertyName}) => {
-            const {encrypt} = options as EncryptedColumnOptions;
+      .filter(({options, mode, target, propertyName}) => {
+          const {encrypt} = options as EncryptedColumnOptions
 
-            return entity[propertyName] &&
-                mode === 'regular' &&
-                encrypt &&
-                (encrypt.looseMatching || entity.constructor === target);
-        })
-        // dedup
-        .filter((item, pos, self) => self.findIndex(v => v.propertyName === item.propertyName) === pos);
+          return entity[propertyName] &&
+            mode === 'regular' &&
+            encrypt &&
+            (encrypt.looseMatching || entity.constructor === target)
+      })
+      // dedup
+      .filter((item, pos, self) => self.findIndex(v => v.propertyName === item.propertyName) === pos)
 
     // encrypt only the requested properties (property changes on update)
     if (includeProperties.length > 0) {
-        validColumns = validColumns.filter(({propertyName}) => includeProperties.includes(propertyName));
+        validColumns = validColumns.filter(({propertyName}) => includeProperties.includes(propertyName))
     }
 
     validColumns
-        .forEach(({propertyName, options}) => {
-            const {encrypt} = options as EncryptedColumnOptions;
-            cb(propertyName, encrypt);
-        });
-};
+      .forEach(({propertyName, options}) => {
+          const {encrypt} = options as EncryptedColumnOptions
+          cb(propertyName, encrypt)
+      })
+}
 
 /**
  * Checks the supplied entity for encrypted columns and encrypts any columns that need it.
@@ -42,15 +42,15 @@ const forMatchingColumns = (entity: ObjectLiteral, cb: (propertyName: string, op
  * @param includeProperties
  */
 export const encrypt = <T extends ObjectLiteral>(entity: T, includeProperties: string[] = []): T => {
-    if (!entity) return entity;
+    if (!entity) return entity
 
     forMatchingColumns(entity, (propertyName, options) => {
         // For any matching columns encrypt the property
-        entity[propertyName] = encryptString(entity[propertyName], options);
-    }, includeProperties);
+        entity[propertyName] = encryptString(entity[propertyName], options)
+    }, includeProperties)
 
-    return entity;
-};
+    return entity
+}
 
 /**
  * Encrypts the supplied string with the columns options.
@@ -59,16 +59,16 @@ export const encrypt = <T extends ObjectLiteral>(entity: T, includeProperties: s
  * @param options The encryption options.
  */
 const encryptString = (string: string, options: EncryptionOptions) => {
-    const buffer = Buffer.from(string, 'utf8');
-    const iv = randomBytes(options.ivLength);
-    const key = Buffer.from(options.key, 'hex');
+    const buffer = Buffer.from(string, 'utf8')
+    const iv = randomBytes(options.ivLength)
+    const key = Buffer.from(options.key, 'hex')
 
-    const cipher = createCipheriv(options.algorithm, key, iv);
-    const start = cipher.update(buffer);
-    const end = cipher.final();
+    const cipher = createCipheriv(options.algorithm, key, iv)
+    const start = cipher.update(buffer)
+    const end = cipher.final()
 
-    return Buffer.concat([iv, start, end]).toString('base64');
-};
+    return Buffer.concat([iv, start, end]).toString('base64')
+}
 
 /**
  * Checks the supplied entity for columns that need decrypting and decrypts them.
@@ -76,15 +76,15 @@ const encryptString = (string: string, options: EncryptionOptions) => {
  * @param entity The typeorm entity to check
  */
 export const decrypt = (entity: ObjectLiteral) => {
-    if (!entity) return entity;
+    if (!entity) return entity
 
     forMatchingColumns(entity, (propertyName, options) => {
         // For any matching columns decrypt the property
-        entity[propertyName] = decryptString(entity[propertyName], options);
-    });
+        entity[propertyName] = decryptString(entity[propertyName], options)
+    })
 
-    return entity;
-};
+    return entity
+}
 
 /**
  * Decrypts the supplied string using the column options.
@@ -93,13 +93,13 @@ export const decrypt = (entity: ObjectLiteral) => {
  * @param options The encryption options.
  */
 const decryptString = (string: string, options: EncryptionOptions) => {
-    const buffer = Buffer.from(string, 'base64');
-    const iv = buffer.slice(0, options.ivLength);
-    const key = Buffer.from(options.key, 'hex');
+    const buffer = Buffer.from(string, 'base64')
+    const iv = buffer.slice(0, options.ivLength)
+    const key = Buffer.from(options.key, 'hex')
 
-    const decipher = createDecipheriv(options.algorithm, key, iv);
-    const start = decipher.update(buffer.slice(options.ivLength));
-    const end = decipher.final();
+    const decipher = createDecipheriv(options.algorithm, key, iv)
+    const start = decipher.update(buffer.slice(options.ivLength))
+    const end = decipher.final()
 
-    return Buffer.concat([start, end]).toString('utf8');
-};
+    return Buffer.concat([start, end]).toString('utf8')
+}

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,50 +1,56 @@
-import {ObjectLiteral, getMetadataArgsStorage} from "typeorm"
-import {EncryptedColumnOptions, EncryptionOptions} from './interfaces'
-import {randomBytes, createCipheriv, createDecipheriv} from 'crypto'
+import {getMetadataArgsStorage, ObjectLiteral} from 'typeorm';
+import {EncryptedColumnOptions, EncryptionOptions} from './interfaces';
+import {createCipheriv, createDecipheriv, randomBytes} from 'crypto';
 
 /**
  * For all columns that have encryption options run the supplied function.
  *
  * @param entity The typeorm Entity.
  * @param cb Function to run for matching columns.
+ * @param includeProperties filter encrypted properties by propertyName
  */
-const forMatchingColumns = (entity: ObjectLiteral, cb: (propertyName: string, options: EncryptionOptions) => void) => {
-  // Iterate through all columns in Typeorm
-  getMetadataArgsStorage().columns
-  // remove duplicate properties in case of inheritance,
-      .filter((item, pos, self) => self.findIndex(v => v.propertyName === item.propertyName) === pos)
-      .forEach((column) => {
-    const {options, propertyName, mode, target} = column
-    const columnOptions = options as EncryptedColumnOptions
-    if(
-      columnOptions.encrypt // Does this column have encryption options
-      &&
-      mode === 'regular' // Is it a regular column
-      &&
-      (columnOptions.encrypt.looseMatching || entity.constructor === target) // Is looseMatching enabled OR is this column from the current entity?
-    ){
-      if (entity[propertyName]) {  // Does the passed entity have the property?
-        cb(propertyName, columnOptions.encrypt)
-      }
+const forMatchingColumns = (entity: ObjectLiteral, cb: (propertyName: string, options: EncryptionOptions) => void, includeProperties: string[] = []) => {
+    // Iterate through all columns in Typeorm
+    let validColumns = getMetadataArgsStorage().columns
+        .filter(({options, mode, target, propertyName}) => {
+            const {encrypt} = options as EncryptedColumnOptions;
+
+            return entity[propertyName] &&
+                mode === 'regular' &&
+                encrypt &&
+                (encrypt.looseMatching || entity.constructor === target);
+        })
+        // dedup
+        .filter((item, pos, self) => self.findIndex(v => v.propertyName === item.propertyName) === pos);
+
+    // encrypt only the requested properties (property changes on update)
+    if (includeProperties.length > 0) {
+        validColumns = validColumns.filter(({propertyName}) => includeProperties.includes(propertyName));
     }
-  })
-}
+
+    validColumns
+        .forEach(({propertyName, options}) => {
+            const {encrypt} = options as EncryptedColumnOptions;
+            cb(propertyName, encrypt);
+        });
+};
 
 /**
  * Checks the supplied entity for encrypted columns and encrypts any columns that need it.
  *
  * @param entity Typeorm Entity to check.
+ * @param includeProperties
  */
-export const encrypt = <T extends ObjectLiteral>(entity: T): T => {
-  if (!entity) return entity
+export const encrypt = <T extends ObjectLiteral>(entity: T, includeProperties: string[] = []): T => {
+    if (!entity) return entity;
 
-  forMatchingColumns(entity, (propertyName, options) => {
-    // For any matching columns encrypt the property
-    entity[propertyName] = encryptString(entity[propertyName], options)
-  })
+    forMatchingColumns(entity, (propertyName, options) => {
+        // For any matching columns encrypt the property
+        entity[propertyName] = encryptString(entity[propertyName], options);
+    }, includeProperties);
 
-  return entity
-}
+    return entity;
+};
 
 /**
  * Encrypts the supplied string with the columns options.
@@ -53,16 +59,16 @@ export const encrypt = <T extends ObjectLiteral>(entity: T): T => {
  * @param options The encryption options.
  */
 const encryptString = (string: string, options: EncryptionOptions) => {
-  const buffer = Buffer.from(string, "utf8")
-  const iv = randomBytes(options.ivLength)
-  const key = Buffer.from(options.key, 'hex')
+    const buffer = Buffer.from(string, 'utf8');
+    const iv = randomBytes(options.ivLength);
+    const key = Buffer.from(options.key, 'hex');
 
-  const cipher = createCipheriv(options.algorithm, key, iv)
-  const start = cipher.update(buffer)
-  const end = cipher.final()
+    const cipher = createCipheriv(options.algorithm, key, iv);
+    const start = cipher.update(buffer);
+    const end = cipher.final();
 
-  return Buffer.concat([iv, start, end]).toString('base64')
-}
+    return Buffer.concat([iv, start, end]).toString('base64');
+};
 
 /**
  * Checks the supplied entity for columns that need decrypting and decrypts them.
@@ -70,15 +76,15 @@ const encryptString = (string: string, options: EncryptionOptions) => {
  * @param entity The typeorm entity to check
  */
 export const decrypt = (entity: ObjectLiteral) => {
-  if (!entity) return entity
+    if (!entity) return entity;
 
-  forMatchingColumns(entity, (propertyName, options) => {
-    // For any matching columns decrypt the property
-    entity[propertyName] = decryptString(entity[propertyName], options)
-  })
+    forMatchingColumns(entity, (propertyName, options) => {
+        // For any matching columns decrypt the property
+        entity[propertyName] = decryptString(entity[propertyName], options);
+    });
 
-  return entity
-}
+    return entity;
+};
 
 /**
  * Decrypts the supplied string using the column options.
@@ -87,13 +93,13 @@ export const decrypt = (entity: ObjectLiteral) => {
  * @param options The encryption options.
  */
 const decryptString = (string: string, options: EncryptionOptions) => {
-  const buffer = Buffer.from(string, 'base64')
-  const iv = buffer.slice(0, options.ivLength)
-  const key = Buffer.from(options.key, 'hex')
+    const buffer = Buffer.from(string, 'base64');
+    const iv = buffer.slice(0, options.ivLength);
+    const key = Buffer.from(options.key, 'hex');
 
-  const decipher = createDecipheriv(options.algorithm, key, iv)
-  const start = decipher.update(buffer.slice(options.ivLength))
-  const end = decipher.final()
+    const decipher = createDecipheriv(options.algorithm, key, iv);
+    const start = decipher.update(buffer.slice(options.ivLength));
+    const end = decipher.final();
 
-  return Buffer.concat([start, end]).toString('utf8')
-}
+    return Buffer.concat([start, end]).toString('utf8');
+};

--- a/src/events.ts
+++ b/src/events.ts
@@ -4,13 +4,16 @@ import {randomBytes, createCipheriv, createDecipheriv} from 'crypto'
 
 /**
  * For all columns that have encryption options run the supplied function.
- * 
+ *
  * @param entity The typeorm Entity.
  * @param cb Function to run for matching columns.
  */
 const forMatchingColumns = (entity: ObjectLiteral, cb: (propertyName: string, options: EncryptionOptions) => void) => {
   // Iterate through all columns in Typeorm
-  getMetadataArgsStorage().columns.forEach((column) => {
+  getMetadataArgsStorage().columns
+  // remove duplicate properties in case of inheritance,
+      .filter((item, pos, self) => self.findIndex(v => v.propertyName === item.propertyName) === pos)
+      .forEach((column) => {
     const {options, propertyName, mode, target} = column
     const columnOptions = options as EncryptedColumnOptions
     if(
@@ -29,7 +32,7 @@ const forMatchingColumns = (entity: ObjectLiteral, cb: (propertyName: string, op
 
 /**
  * Checks the supplied entity for encrypted columns and encrypts any columns that need it.
- * 
+ *
  * @param entity Typeorm Entity to check.
  */
 export const encrypt = <T extends ObjectLiteral>(entity: T): T => {
@@ -45,7 +48,7 @@ export const encrypt = <T extends ObjectLiteral>(entity: T): T => {
 
 /**
  * Encrypts the supplied string with the columns options.
- * 
+ *
  * @param string The string to encrypt.
  * @param options The encryption options.
  */
@@ -63,7 +66,7 @@ const encryptString = (string: string, options: EncryptionOptions) => {
 
 /**
  * Checks the supplied entity for columns that need decrypting and decrypts them.
- * 
+ *
  * @param entity The typeorm entity to check
  */
 export const decrypt = (entity: ObjectLiteral) => {
@@ -79,7 +82,7 @@ export const decrypt = (entity: ObjectLiteral) => {
 
 /**
  * Decrypts the supplied string using the column options.
- * 
+ *
  * @param string The string to decrypt,
  * @param options The encryption options.
  */

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -48,9 +48,15 @@ test('It should encrypt data', async () => {
   let connection = getConnection()
   let repository = connection.getRepository(Test)
 
-  await repository.save(entity)
+  const result = await repository.save(entity)
 
-  expect(entity.secret).not.toBe('test')
+  expect(result.secret).toBe('testing') // decrypted after insert
+
+  const raw = await repository
+    .createQueryBuilder('test')
+    .getRawOne()
+
+  expect(raw.test_secret).not.toBe('testing') // properly encrypted in db
 })
 
 test('It should fetch encrypted data', async () => {
@@ -79,6 +85,12 @@ test('it should update data', async () => {
   let u = await repository.findOneOrFail()
 
   expect(u.secret).toBe('tested')
+
+  const raw = await repository
+    .createQueryBuilder('test')
+    .getRawOne()
+
+  expect(raw.test_secret).not.toBe('tested') // properly encrypted in db
 })
 
 test('N:N relation should be saved', async () => {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -72,7 +72,9 @@ test('it should update data', async () => {
 
   t.secret = 'tested'
 
-  await repository.save(t)
+  const result = await repository.save(t)
+
+  expect(result.secret).toBe('tested')
 
   let u = await repository.findOneOrFail()
 

--- a/src/subscriber.ts
+++ b/src/subscriber.ts
@@ -13,6 +13,11 @@ export class Subscriber implements EntitySubscriberInterface {
     encrypt(event.entity, updatedColumns)
   }
 
+  afterUpdate(event: UpdateEvent<ObjectLiteral>) {
+    const updatedColumns = event.updatedColumns.map(({propertyName}) => propertyName)
+    decrypt(event.entity, updatedColumns)
+  }
+
   afterLoad(entity: ObjectLiteral) {
     decrypt(entity)
   }

--- a/src/subscriber.ts
+++ b/src/subscriber.ts
@@ -9,7 +9,8 @@ export class Subscriber implements EntitySubscriberInterface{
   }
 
   beforeUpdate(event: UpdateEvent<ObjectLiteral>){
-    encrypt(event.entity)
+    const updatedColumns = event.updatedColumns.map(({propertyName}) => propertyName)
+    encrypt(event.entity, updatedColumns)
   }
 
   afterLoad(entity: ObjectLiteral){

--- a/src/subscriber.ts
+++ b/src/subscriber.ts
@@ -8,6 +8,10 @@ export class Subscriber implements EntitySubscriberInterface {
     encrypt(event.entity)
   }
 
+  afterInsert(event: InsertEvent<ObjectLiteral>): Promise<any> | void {
+    decrypt(event.entity)
+  }
+
   beforeUpdate(event: UpdateEvent<ObjectLiteral>) {
     const updatedColumns = event.updatedColumns.map(({propertyName}) => propertyName)
     encrypt(event.entity, updatedColumns)

--- a/src/subscriber.ts
+++ b/src/subscriber.ts
@@ -1,19 +1,19 @@
-import {EventSubscriber, EntitySubscriberInterface, InsertEvent, ObjectLiteral, UpdateEvent} from 'typeorm'
+import {EntitySubscriberInterface, EventSubscriber, InsertEvent, ObjectLiteral, UpdateEvent} from 'typeorm'
 
-import {encrypt, decrypt} from './events'
+import {decrypt, encrypt} from './events'
 
 @EventSubscriber()
-export class Subscriber implements EntitySubscriberInterface{
-  beforeInsert(event: InsertEvent<ObjectLiteral>){
+export class Subscriber implements EntitySubscriberInterface {
+  beforeInsert(event: InsertEvent<ObjectLiteral>) {
     encrypt(event.entity)
   }
 
-  beforeUpdate(event: UpdateEvent<ObjectLiteral>){
+  beforeUpdate(event: UpdateEvent<ObjectLiteral>) {
     const updatedColumns = event.updatedColumns.map(({propertyName}) => propertyName)
     encrypt(event.entity, updatedColumns)
   }
 
-  afterLoad(entity: ObjectLiteral){
+  afterLoad(entity: ObjectLiteral) {
     decrypt(entity)
   }
 }


### PR DESCRIPTION
Hi, 

This pr fix 2 problem

1. in case of class inheritance, calling `getMetadataArgsStorage().columns` yield dupplicate columns metadata. Resulting in multiple encrypt process on the same attribute.

2. when updating a resource, regardless of the changed properties. All the properties are encrypted resulting in double encryption.

